### PR TITLE
Tooltip

### DIFF
--- a/scripts/resource_nodes/resource_nodes.gml
+++ b/scripts/resource_nodes/resource_nodes.gml
@@ -140,6 +140,10 @@ function draw_resource_plot(_nodeid) {
 		draw_text(x+32,y+32,print_num(_cost))
 		draw_set_color(c_white)
 	}
+	if _resource_plot.hovered {
+		tooltip_string = string_concat("This patch of land costs ", print_num(_resource_plot.slot_cost), " gold.")
+		draw_text(50 + string_width(tooltip_string) / 2, 50, tooltip_string)
+	}
 }
 
 function buy_node_plot(_nodeid) {


### PR DESCRIPTION
Wrote a basic tooltip for unbought land, will probably do something similar for bought land, in case the level and cost numbers are hard to see, if possible I'd like to have it come off the mouse instead